### PR TITLE
Fix printf, sprintf, snprintf not declared errors

### DIFF
--- a/gdb.cpp
+++ b/gdb.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <cstdio>
 #include <numeric>
 #include <SDL2/SDL_net.h>
 
@@ -155,13 +156,13 @@ namespace GDB {
 
 	IPaddress ip;
 	if( SDLNet_ResolveHost( &ip, nullptr, port ) == -1 ){
-	    printf("SDLNet_ResolveHost: %s\n", SDLNet_GetError());
+	    std::printf("SDLNet_ResolveHost: %s\n", SDLNet_GetError());
 	    return false;
 	}
 	
 	server = SDLNet_TCP_Open(&ip);
 	if (!server) {
-	    printf("SDLNet_TCP_Open: %s\n", SDLNet_GetError());
+	    std::printf("SDLNet_TCP_Open: %s\n", SDLNet_GetError());
 	    return false;
 	}
 
@@ -187,7 +188,7 @@ namespace GDB {
 	u8 checksum = std::accumulate(raw.begin(), raw.end(), 0);
 
 	char hex[3];
-	snprintf(hex, 3, "%02x", u32(checksum));
+	std::snprintf(hex, 3, "%02x", u32(checksum));
 	s += hex;
 
 	if( noAckMode ){
@@ -217,7 +218,7 @@ namespace GDB {
 
 	READ_SREG_INTO(g->avr, sreg);
 
-	snprintf(cmd, 64, "T%02x20:%02x;21:%02x%02x;22:%02x%02x%02x00;",
+	std::snprintf(cmd, 64, "T%02x20:%02x;21:%02x%02x;22:%02x%02x%02x00;",
 		signal ? signal : 5,
 		 CPU::reg[16].I,
 		 CPU::reg[13].I,
@@ -279,12 +280,12 @@ namespace GDB {
 	    u32 i;
 
 	    for( i=0; i<16; ++i, outp += 8 )
-		sprintf(outp, "%08x", rev32(CPU::reg[i].I) );
+		std::sprintf(outp, "%08x", rev32(CPU::reg[i].I) );
 
 	    for( i=0; i<12; ++i, outp += 16 )
-		sprintf(outp, "0000000000000000");
+		std::sprintf(outp, "0000000000000000");
 
-	    sprintf(outp, "00000000"); outp+=8; // FPSR
+	    std::sprintf(outp, "00000000"); outp+=8; // FPSR
 
 	    write(out);
 	    
@@ -298,7 +299,7 @@ namespace GDB {
 		i = 16;
 		CPU::CPUUpdateCPSR();
 	    }
-	    sprintf(out, "%08x", rev32(CPU::reg[i].I));
+	    std::sprintf(out, "%08x", rev32(CPU::reg[i].I));
 	    write(out);
 	    break;
 	}
@@ -312,7 +313,7 @@ namespace GDB {
 	    // std::cout << std::hex << addr << ", " << len << std::endl;
 	    for( u32 i=0; i<len; ++i, outp += 2 ){
 		if( addr+i > 0x30000000 ) break;
-		sprintf( outp, "%02x", MMU::read8( addr+i ) );
+		std::sprintf( outp, "%02x", MMU::read8( addr+i ) );
 	    }
 	    
 	    write( out );


### PR DESCRIPTION
When downloading and trying to compile the code I got the following error messages:

> error: 'printf' was not declared in this scope
> error: 'snprintf' was not declared in this scope
> error: 'sprintf' was not declared in this scope

This commit rectifies that error by including the necessary standard header and qualifying the necessary functions.